### PR TITLE
Add cancellation possibilities

### DIFF
--- a/event.go
+++ b/event.go
@@ -3,8 +3,9 @@ package emitter
 // Event is a structure to send events contains
 // some helpers to cast primitive types easily.
 type Event struct {
-	Topic string
-	Args  []interface{}
+	Topic, OriginalTopic string
+	Flags                Flag
+	Args                 []interface{}
 }
 
 // Int returns casted into int type argument by index.


### PR DESCRIPTION
Also service event like `listener:new` removed. Because there is
no guarantee that event will delivered synchronously. In other
case cancellation should be added as well.