### PR TITLE
Abstracted path.Matcher to Matcher interface

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,20 @@
+package emitter
+
+import (
+	"path"
+)
+
+type Matcher interface {
+	Match(pattern, name string) (matched bool, err error)
+}
+
+func DefaultMatcher() Matcher {
+	return &PathMatch{}
+}
+
+type PathMatch struct {
+}
+
+func (p *PathMatch) Match(pattern, name string) (matched bool, err error) {
+	return path.Match(pattern, name)
+}


### PR DESCRIPTION
Hello,

I had a project where I was using your library, but needed different matching than path.Match (our strings have "/" in them, but are not paths). 

So I pulled the match functionality out into an interface to make it easier to override. Thought I'd push it back and see if it was useful.

Thanks for the cool library.