### PR TITLE
Allow for capacity to be set per listener

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -1,9 +1,9 @@
 /*
 Package emitter implements channel based pubsub pattern.
 The design goals are:
-	- fully functional and safety
-	- simple to understand and use
-	- make the code readable, maintainable and minimalistic
+  - fully functional and safety
+  - simple to understand and use
+  - make the code readable, maintainable and minimalistic
 */
 package emitter
 
@@ -54,7 +54,8 @@ func Close(e *Event) { e.Flags = e.Flags | FlagClose }
 func Sync(e *Event) { e.Flags = e.Flags | FlagSync }
 
 // New returns just created Emitter struct. Capacity argument
-// will be used to create channels with given capacity
+// will be used to create channels with given capacity by default. The
+// OnWithCap method can be used to get different capacities per listener.
 func New(capacity uint) *Emitter {
 	return &Emitter{
 		Cap:         capacity,
@@ -110,9 +111,15 @@ func (e *Emitter) Use(pattern string, middlewares ...func(*Event)) {
 // On returns a channel that will receive events. As optional second
 // argument it takes middlewares.
 func (e *Emitter) On(topic string, middlewares ...func(*Event)) <-chan Event {
+	return e.OnWithCap(topic, e.Cap, middlewares...)
+}
+
+// On returns a channel that will receive events with the listener capacity
+// specified. As optional second argument it takes middlewares.
+func (e *Emitter) OnWithCap(topic string, capacity uint, middlewares ...func(*Event)) <-chan Event {
 	e.mu.Lock()
 	e.init()
-	l := newListener(e.Cap, middlewares...)
+	l := newListener(capacity, middlewares...)
 	if listeners, ok := e.listeners[topic]; ok {
 		e.listeners[topic] = append(listeners, l)
 	} else {

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -306,6 +306,18 @@ func TestCallbackOnlyUsage(t *testing.T) {
 	expect(t, called, true)
 }
 
+func TestCustomCap(t *testing.T) {
+	// Default is no capacity
+	ee := New(0)
+	// Listen with extended capacity, use Skip to avoid hang
+	pipe := ee.OnWithCap("test", 2, Skip)
+
+	<-ee.Emit("test", 0)
+	<-ee.Emit("test", 1)
+	<-ee.Emit("test", 2) // should get dropped, proves 2 was used
+	expect(t, len(pipe), 2)
+}
+
 func expect(t *testing.T, a interface{}, b interface{}) {
 	if a != b {
 		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))


### PR DESCRIPTION
This adds a OnWithCap method to Emitter which allows the listener capacity to be set for that call. This is useful because different use cases often benefit from different amounts of buffering, especially when an Emitter instance is shared for multiple uses in a non-trivial application.

The pre-existing On method still works as it did before, but now calls OnWithCap.